### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/part1/README.md
+++ b/part1/README.md
@@ -468,7 +468,7 @@ h1 {
   text-align: center;
 }
 
-#color {
+# color {
   width: 300px;
   height: 300px;
   margin: 0 auto;


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
